### PR TITLE
Refactor project for modern, responsive, trendy design

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,6 +6,7 @@ import "@/css/layout.css";
 import "@/css/component.css";
 import "@/css/page.css";
 import "@/css/response.css";
+import "@/css/theme.css";
 
 function App() {
   return (

--- a/src/css/theme.css
+++ b/src/css/theme.css
@@ -1,0 +1,138 @@
+@charset "utf-8";
+
+/* =========================================================
+   Theme: Modern Blue & White (#0000FF & #FFFFFF)
+   Applied as overrides, minimal disruption
+   ========================================================= */
+
+:root {
+  --brand: #0000FF;
+  --brand-ink: #0000FF;
+  --text-strong: #0b1220;
+  --text-muted: #6b7280;
+  --chat-fab-size: 68px;
+}
+
+/* Base */
+html, body {
+  background: #fff;
+  color: var(--text-strong);
+}
+body {
+  min-width: auto !important;
+}
+
+/* Focus states */
+a:focus-visible,
+button:focus-visible,
+input:focus-visible,
+select:focus-visible,
+textarea:focus-visible,
+.btn:focus-visible {
+  outline: 2px solid var(--brand);
+  outline-offset: 2px;
+}
+
+/* Layout width: fluid container on desktop */
+.header > .inner,
+.all_menu.WEB .inner,
+.footer .inner,
+.c_wrap {
+  width: min(1200px, 100%) !important;
+  padding-left: 20px;
+  padding-right: 20px;
+}
+
+/* Header accents */
+.scroll-progress { background: var(--brand) !important; }
+.btnAllMenu.active { background: var(--brand) !important; border-color: var(--brand) !important; color: #fff !important; }
+.header .gnb ul li a.cur,
+.header .gnb ul li a:hover { color: var(--brand) !important; }
+.header .user_info .person { color: var(--brand) !important; }
+
+/* Mobile user info */
+.user_info_m .person { color: var(--brand) !important; }
+.user_info_m .login,
+.user_info_m .logout {
+  background: var(--brand) !important;
+  color: #fff !important;
+}
+
+/* Buttons */
+.btn_blue_h46,
+.btn_upload { background: var(--brand) !important; color: #fff !important; }
+
+.btn_skyblue_h46,
+.btn_down,
+.replay .right_col .btn {
+  background: #fff !important;
+  color: var(--brand) !important;
+  border: 1px solid var(--brand) !important;
+}
+
+/* Titles */
+.tit_1::after,
+.tit_4::before { background: var(--brand) !important; }
+
+/* Links */
+.file_attach a,
+.board_attach dl dd a { color: var(--brand) !important; }
+
+/* Pagination */
+.paging ul li button.cur {
+  background: var(--brand) !important;
+  color: #fff !important;
+}
+
+/* Forms focus polish */
+.f_input2:focus,
+.f_txtar:focus,
+.f_search2 input[type="text"]:focus {
+  border-color: color-mix(in srgb, var(--brand) 60%, #ffffff) !important;
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--brand) 20%, #ffffff) !important;
+}
+
+/* Nav current */
+.header .gnb a.cur { color: var(--brand) !important; }
+
+/* Chat: unify to blue & white */
+.chat-fab {
+  background: var(--brand) !important;
+  border: 2px solid rgba(255,255,255,0.9) !important;
+}
+.chat-msg.me .bubble { background: var(--brand) !important; color: #fff !important; }
+.chat-input button { background: var(--brand) !important; color: #fff !important; }
+.chat-head-left strong {
+  background: none !important;
+  -webkit-text-fill-color: var(--brand) !important;
+  color: var(--brand) !important;
+}
+.chat-head-left .chat-head-icon {
+  background: var(--brand) !important;
+  color: #fff !important;
+}
+/* Chips: blue-white aesthetic */
+.chat-panel .chip,
+.chat-panel .chip.t-transform,
+.chat-panel .chip.t-security,
+.chat-panel .chip.t-guide,
+.chat-panel .chip.t-inform,
+.chat-panel .chip.t-download,
+.chat-panel .chip.t-default {
+  --bg: linear-gradient(135deg, #ffffff 0%, #e6f0ff 100%) !important;
+  --fg: #0b1220 !important;
+}
+
+/* Header login button */
+.header .user_info .btn.login {
+  background: var(--brand) !important;
+  color: #fff !important;
+  border-color: var(--brand) !important;
+}
+
+/* Page-specific accents */
+.P_MAIN .mini_board .tab li a.on::after { background: var(--brand) !important; }
+.Plogin .login_box button { background: var(--brand) !important; }
+
+/* Tweak chat FAB default size back to a reasonable value */
+:root { --chat-fab-size: 68px; }


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [ ] 버그수정 Bug fixes
- [x] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

검토자를 위해 수정된 소스 내용을 설명해 주세요. Please describe the modified source for reviewers.

사용자 요청에 따라 #0000FF와 흰색 조합의 모던하고 반응형 UI 테마를 적용하여 전반적인 디자인을 개선했습니다.

주요 변경 사항은 다음과 같습니다:
*   새로운 `src/css/theme.css` 파일을 추가하여 전역 색상 변수 및 핵심 UI 컴포넌트(헤더, 버튼, 폼, 페이징, 채팅 등)에 테마를 적용했습니다.
*   `src/App.jsx`에 `theme.css`를 임포트하여 기존 스타일을 오버라이드했습니다.
*   `body`의 `min-width`를 해제하고 주요 레이아웃 컨테이너의 너비를 `min(1200px, 100%)`로 조정하여 반응형 레이아웃을 개선했습니다.
*   주요 인터랙션 요소의 `:focus-visible` 아웃라인을 브랜드 색상으로 통일했습니다.

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [ ] JUnit 테스트 JUnit tests
- [x] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

테스트 전과 후의 스크린샷 또는 캡처 영상을 이곳에 첨부해 주세요. Please attach screenshots or video captures of your before and after tests here.

---
<a href="https://cursor.com/background-agent?bcId=bc-99c4bfad-8222-4f27-93c0-16b79e293c34">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-99c4bfad-8222-4f27-93c0-16b79e293c34">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

